### PR TITLE
Improved error messages

### DIFF
--- a/sankey.py
+++ b/sankey.py
@@ -69,6 +69,10 @@ def sankey(left, right, leftWeight=None, rightWeight=None, colorDict=None,
     plt.rc('font', family='serif')
 
     # Create Dataframe
+    if isinstance(left, pd.Series):
+        left = left.reset_index(drop=True)
+    if isinstance(right, pd.Series):
+        right = right.reset_index(drop=True)
     df = pd.DataFrame({'left': left, 'right': right, 'leftWeight': leftWeight,
                        'rightWeight': rightWeight}, index=range(len(left)))
     


### PR DESCRIPTION
1. Checks if left and right are Series, if so, removes their index.
2. Checks if the resulting DataFrame has null values, if so, raises an error.
3. Checks if leftLabels matches the values in left, if not, raises an error.
4. Same as 3, except for the right.
5. If colorDict is specified, ensures that it has a value for all labels.

These checks are added to improve the error messaging generated so that it isn't a generic matplotlib ValueError saying "posx and posy should be finite values"