### PR TITLE
Matplotlib default backend

### DIFF
--- a/pysankey/sankey.py
+++ b/pysankey/sankey.py
@@ -18,6 +18,8 @@ Produces simple Sankey Diagrams with matplotlib.
 
 from collections import defaultdict
 
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
Hello,

So I've been trying to use the 0.0.1 version on pypi and I got the following error :  `TclError: no display name and no $DISPLAY environment variable`. I already had this problem before and following this stack question [here](https://stackoverflow.com/questions/37604289/tkinter-tclerror-no-display-name-and-no-display-environment-variable) I remembered that I already fixed it in my copy pasted version. 

Apparently I forgot to make a pull request for it ? It's also possible that you removed it during merge, and you don't want this in your code (because if matplotlib is already used elsewhere we cannot change the backend...) ?

Let me know if it break something for you :)
