### PR TITLE
Fix syntax errors on lines 42 and 126

### DIFF
--- a/pysankey/sankey.py
+++ b/pysankey/sankey.py
@@ -39,7 +39,7 @@ class LabelMismatch(PySankeyException):
 
 
 def check_data_matches_labels(labels, data, side):
-    if len(labels > 0):
+    if len(labels) > 0:
         if isinstance(data, list):
             data = set(data)
         if isinstance(data, pd.Series):
@@ -123,7 +123,7 @@ def sankey(left, right, leftWeight=None, rightWeight=None, colorDict=None,
     if len(rightLabels) == 0:
         rightLabels = pd.Series(dataFrame.right.unique()).unique()
     else:
-        check_data_matches_labels(leftLabels, dataFrame['right'], 'right')
+        check_data_matches_labels(rightLabels, dataFrame['right'], 'right')
     # If no colorDict given, make one
     if colorDict is None:
         colorDict = {}


### PR DESCRIPTION
Fix paren placement on line 42.

Line 126 is supposed to check `rightLabels` instead of `leftLabels`, the latter already having been checked 6 lines earlier.