### PR TITLE
Fixed a typo in the check_data_matches_labels

### DIFF
--- a/pysankey/sankey.py
+++ b/pysankey/sankey.py
@@ -39,7 +39,7 @@ class LabelMismatch(PySankeyException):
 
 
 def check_data_matches_labels(labels, data, side):
-    if len(labels > 0):
+    if len(labels) > 0:
         if isinstance(data, list):
             data = set(data)
         if isinstance(data, pd.Series):


### PR DESCRIPTION
There was a typo in the check_data_matches_labels function.
It was: if len(labels > 0): instead of if len(labels) > 0:
This made it impossible to use the ordering of the names capability.
Other than that, great library!