### PR TITLE
Fixed index mismatch issue when passing a dataframe to the sankey function which has been sorted in any way

### DIFF
--- a/pysankey/sankey.py
+++ b/pysankey/sankey.py
@@ -104,6 +104,10 @@ def sankey(left, right, leftWeight=None, rightWeight=None, colorDict=None,
         left = left.reset_index(drop=True)
     if isinstance(right, pd.Series):
         right = right.reset_index(drop=True)
+    if isinstance(leftWeight, pd.Series):
+        leftWeight = leftWeight.reset_index(drop=True)
+    if isinstance(rightWeight, pd.Series):
+        rightWeight = rightWeight.reset_index(drop=True)
     dataFrame = pd.DataFrame({'left': left, 'right': right, 'leftWeight': leftWeight,
                               'rightWeight': rightWeight}, index=range(len(left)))
 

--- a/pysankey/sankey.py
+++ b/pysankey/sankey.py
@@ -127,7 +127,7 @@ def sankey(left, right, leftWeight=None, rightWeight=None, colorDict=None,
     if len(rightLabels) == 0:
         rightLabels = pd.Series(dataFrame.right.unique()).unique()
     else:
-        check_data_matches_labels(leftLabels, dataFrame['right'], 'right')
+        check_data_matches_labels(rightLabels, dataFrame['right'], 'right')
     # If no colorDict given, make one
     if colorDict is None:
         colorDict = {}


### PR DESCRIPTION
Hi there  👋 

Two small changes here.

Noticed an issue when using this module the other day where if you pass a dataframe that has been sorted based on the weights, the output is incorrect (see example attached below). I did a bit of digging and I noticed that this is because you reindex `left` and `right` if they are passed as a series but not the `leftWeight` and `rightWeight`, so when you then create the `dataFrame` variable, there is in index mismatch and the values get jumbled up basically.

second thing I noticed is that when you `check_data_matches_labels`on the right hand side, you were actually passing in the `leftLabels` rather than the `rightLabels` which I think is incorrect.


## Example

### Sample dataset

```
left,right,weight
apple,apple, 2
apple,orange, 3
apple,banana,3
orange,apple,5
orange,orange,7
orange,banana,2
banana,apple,4
banana,orange,1
banana,banana,0
```

## Create Sankey's

```python
import pandas as pd 
from pySankey.sankey import sankey


data = pd.read_csv("sample_data.csv")


# Example 1: No reordering
sankey(
    left=data["left"], right=data["right"], 
    leftWeight=data["weight"], rightWeight=data["weight"], 
    aspect=20, fontsize=20
)


# Example 2: Some sorting applied (notice the difference in banana -> orange, and orange -> orange)
data_sorted = data.sort_values(by="weight")
sankey(
    left=data_sorted["left"], right=data_sorted["right"], 
    leftWeight=data_sorted["weight"], rightWeight=data_sorted["weight"], 
    aspect=20, fontsize=20
)
```