### PR TITLE
👨‍🚒Hotfix: labels order functionnality enabled

### DIFF
--- a/pysankey/sankey.py
+++ b/pysankey/sankey.py
@@ -123,7 +123,7 @@ def sankey(left, right, leftWeight=None, rightWeight=None, colorDict=None,
     if len(rightLabels) == 0:
         rightLabels = pd.Series(dataFrame.right.unique()).unique()
     else:
-        check_data_matches_labels(leftLabels, dataFrame['right'], 'right')
+        check_data_matches_labels(rightLabels, dataFrame['right'], 'right')
     # If no colorDict given, make one
     if colorDict is None:
         colorDict = {}

--- a/pysankey/sankey.py
+++ b/pysankey/sankey.py
@@ -39,7 +39,7 @@ class LabelMismatch(PySankeyException):
 
 
 def check_data_matches_labels(labels, data, side):
-    if len(labels > 0):
+    if len(labels) > 0:
         if isinstance(data, list):
             data = set(data)
         if isinstance(data, pd.Series):


### PR DESCRIPTION
Current version is breaking when the user provides  `leftLabels` or `rightLabels` arguments. 
This small bug was fixed in this PR.